### PR TITLE
Log error as last parameter in 40x errors

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -29,28 +29,28 @@ function _renderErrorPage(res, req, statusCode, i18n, isProd, lang, err) {
 
   switch (statusCode) {
     case 400:
-      log.info({ err }, `400 Bad request ${err.message}`)
+      log.info(`400 Bad request ${err.message}`, { err })
       headTitle = i18n.message('error_400_head_title', lang)
       headDescription = i18n.message('error_400_description', lang)
       title = i18n.message('error_400_title', lang)
       text = i18n.message('error_400_text', lang)
       break
     case 401:
-      log.info({ err }, `401 Unauthorized ${err.message}`)
+      log.info(`401 Unauthorized ${err.message}`, { err })
       headTitle = i18n.message('error_401_head_title', lang)
       headDescription = i18n.message('error_401_description', lang)
       title = i18n.message('error_401_title', lang)
       text = i18n.message('error_401_text', lang)
       break
     case 403:
-      log.info({ err }, `403 Forbidden ${err.message}`)
+      log.info(`403 Forbidden ${err.message}`, { err })
       headTitle = i18n.message('error_403_head_title', lang)
       headDescription = i18n.message('error_403_description', lang)
       title = i18n.message('error_403_title', lang)
       text = i18n.message('error_403_text', lang)
       break
     case 404:
-      log.info({ err }, `404 Not found ${err.message}`)
+      log.info(`404 Not found ${err.message}`, { err })
       headTitle = i18n.message('error_404_head_title', lang)
       headDescription = i18n.message('error_404_description', lang)
       title = i18n.message('error_404_title', lang)
@@ -64,6 +64,7 @@ function _renderErrorPage(res, req, statusCode, i18n, isProd, lang, err) {
       link3 = i18n.message('error_404_link_3', lang)
       break
     default:
+      // Log err as first parameter here, which will cause an Exception event in application-insights
       log.error({ err }, `Unhandled error ${err.message}`)
       headTitle = i18n.message('error_500_head_title', lang)
       headDescription = i18n.message('error_500_description', lang)


### PR DESCRIPTION
This will in turn change the way Bunyan formats the logs, and will not lead to Exceptions in Application Insights