### PR TITLE
added support for site name and locale text in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ route.use('/app/mount/point', require('@kth/kth-node-web-common/lib/web/cortina'
   hostUrl: 'http://server_host:port',
   redisConfig: { ... }, // Optional redis config object, see kth-node-configuration.
   globalLink: true, // Default false if not set, if true the language link point to the startpage of KTH,
-  supportedLanguages: ['sv'] // Optional - set to languges supported - if only one language is supported, globalLink sets to true
+  supportedLanguages: ['sv'], // Optional - set to languges supported - if only one language is supported, globalLink sets to true
+  siteNameKey = 'site_name', // Defaults to site_name. This key need to be set in i18n messages file
+  localeTextKey = 'locale_text', // Defaults to locale_text. This key need to be set in i18n messages file
 }))
 ```
 

--- a/lib/web/cortina.js
+++ b/lib/web/cortina.js
@@ -18,7 +18,16 @@ const language = require('../language')
 
 module.exports = function cortinaCommon(options) {
   const cortinaBlockUrl = options.blockUrl // config.blockApi.blockUrl
-  const { headers, addBlocks, proxyPrefixPath, hostUrl, redisConfig, redisKey } = options
+  const {
+    headers,
+    addBlocks,
+    proxyPrefixPath,
+    hostUrl,
+    redisConfig,
+    redisKey,
+    siteNameKey = 'site_name',
+    localeTextKey = 'locale_text',
+  } = options
   let { supportedLanguages = ['sv', 'en'] } = options
   if (!supportedLanguages.length) supportedLanguages = ['sv', 'en']
   const globalLink = supportedLanguages.length === 1 ? true : options.globalLink || false
@@ -35,10 +44,10 @@ module.exports = function cortinaCommon(options) {
       // simply comment out the appropriate lines of code
 
       // this sets the site name shown in the header
-      siteName: i18n.message('site_name', lang),
+      siteName: i18n.message(siteNameKey, lang),
 
       // this needs to be set to the "opposite" of the current language
-      localeText: i18n.message('locale_text', lang === 'en' ? 'sv' : 'en'),
+      localeText: i18n.message(localeTextKey, lang === 'en' ? 'sv' : 'en'),
 
       urls: {
         // baseUrl is the location where the router was mounted. This solves a particular problem with


### PR DESCRIPTION
This pr makes it possible to render  name and locale text for intranet header. Before, these were hard coded in the package.