### PR TITLE
changed breadcrumbs config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes for major version updates will be documented here.
 
+## 8.2.0
+
+- **Breaking:** function `registerBreadcrumbHelper` no longer takes any config used to define "default" breadcrumbs. All breadcrumbs are no sent to `res.render`.
+
 ## 8.0.0
 
 - The error page can now be rendered directly from inside the package. No need to copy and register the Handlebars-file from the app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes for major version updates will be documented here.
 
 ## 8.2.0
 
-- **Breaking:** function `registerBreadcrumbHelper` no longer takes any config used to define "default" breadcrumbs. All breadcrumbs are no sent to `res.render`.
+- **Breaking:** function `registerBreadcrumbHelper` no longer takes any config used to define "default" breadcrumbs. All breadcrumbs are now sent to `res.render`.
+- **Breaking:** are changed, import with `const {registerBreadcrumbHelper} = require('@kth/kth-node-web-common/lib/handlebars/helpers/breadcrumbs')`
 
 ## 8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes for major version updates will be documented here.
 
-## 8.2.0
+## 9.0.0
 
 - **Breaking:** function `registerBreadcrumbHelper` no longer takes any config used to define "default" breadcrumbs. All breadcrumbs are now sent to `res.render`.
 - **Breaking:** are changed, import with `const {registerBreadcrumbHelper} = require('@kth/kth-node-web-common/lib/handlebars/helpers/breadcrumbs')`

--- a/lib/handlebars/helpers/__snapshots__/breadcrumbs.test.js.snap
+++ b/lib/handlebars/helpers/__snapshots__/breadcrumbs.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getBreadcrumbsMarkup should generate breadcrumbs HTML for a valid path list in English 1`] = `
+"
+  <nav id="breadcrumbs" aria-label="Breadcrumbs" class="col-12 col-md-9">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="/">Kth</a></li><li class="breadcrumb-item"><a href="/test1">Test 1</a></li><li class="breadcrumb-item"><a href="/test2">Test 2</a></li>
+    </ol>
+  </nav>
+"
+`;
+
+exports[`getBreadcrumbsMarkup should generate breadcrumbs HTML for a valid path list in Swedish 1`] = `
+"
+  <nav id="breadcrumbs" aria-label="Brödsmulor" class="col-12 col-md-9">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="/">Kth</a></li><li class="breadcrumb-item"><a href="/test1">Test 1</a></li><li class="breadcrumb-item"><a href="/test2">Test 2</a></li>
+    </ol>
+  </nav>
+"
+`;

--- a/lib/handlebars/helpers/breadcrumbs.js
+++ b/lib/handlebars/helpers/breadcrumbs.js
@@ -1,24 +1,11 @@
-/* eslint no-use-before-define: ["error", "nofunc"] */
-
 // @ts-check
 
 const Handlebars = require('handlebars')
 const log = require('@kth/log')
-const i18n = require('kth-node-i18n')
 
-module.exports = registerBreadcrumbHelper
-
-/**
- * Register
- *
- * @param {string} host URL of homepage, e.g. "https://www.kth.se"
- * @param {string} hostNameKey caption of homepage-link, e.g. "KTH"
- * @param {string} basePath URL of section, e.g. "https://www.kth.se/utbildning"
- * @param {string} baseNameKey caption of section-link, e.g. "Utbildning"
- */
-function registerBreadcrumbHelper(host, hostNameKey, basePath, baseNameKey) {
+module.exports = function registerBreadcrumbHelper() {
   /**
-   * @param {object[]} pathList with items { url: '...', label: '...' } or { label: '...' }
+   * @param {{url: string, label: string}} pathList
    * @param {string} lang, e.g. "en"
    *
    * @returns {Handlebars.SafeString|null} HTML as safe string (no need to escape)
@@ -30,35 +17,21 @@ function registerBreadcrumbHelper(host, hostNameKey, basePath, baseNameKey) {
     const pathListIsValid =
       Array.isArray(pathList) &&
       pathList.every(
-        item => item != null && typeof item === 'object' && typeof item.label === 'string' && item.label !== ''
+        item => typeof item.label === 'string' && item.label !== '' && typeof item.url === 'string' && item.url !== ''
       )
     if (!pathListIsValid) {
       log.warn('[breadcrumbs] helper requires first parameter to be a list of path item objects')
       return null
     }
 
-    const protocolOfPage = host ? new URL(host).protocol : ''
-    const hostUrl = host ? host.replace(/^https?:\/\//, `${protocolOfPage}//`) : 'https://www.kth.se'
-
-    if (!host || !hostNameKey) {
-      log.warn('Breadcrumbs helper did not get hostName and hostNameKey, defaulting to www.kth.se and KTH')
-    }
-
+    /**
+     * list of anchor tags
+     * @type {string[]}
+     */
     const listItems = []
 
-    const captionHost = host && hostNameKey ? i18n.message(hostNameKey, lang) : 'KTH'
-    listItems.push(`<a href="${hostUrl}">${captionHost}</a>`)
-
-    if (basePath) {
-      const captionBase = i18n.message(baseNameKey, lang)
-      listItems.push(`<a href="${hostUrl}${basePath}">${captionBase}</a>`)
-    }
-
-    pathList.forEach(item => {
-      if (typeof item.url === 'string' && item.url !== '') {
-        const _url = item.url.replace(/^https?:\/\//, `${protocolOfPage}//`)
-        listItems.push(`<a href="${_url}">${item.label}</a>`)
-      }
+    pathList.forEach(({ url, label }) => {
+      listItems.push(`<a href="${url}">${label}</a>`)
     })
 
     const ariaLabel = /^sv/.test(lang) ? 'Brödsmulor' : 'Breadcrumbs'

--- a/lib/handlebars/helpers/breadcrumbs.js
+++ b/lib/handlebars/helpers/breadcrumbs.js
@@ -3,49 +3,65 @@
 const Handlebars = require('handlebars')
 const log = require('@kth/log')
 
-module.exports = function registerBreadcrumbHelper() {
+/**
+ * @param {{url: string, label: string}[]} pathList
+ * @param {string} lang
+ *
+ * @returns {string} HTML as string
+ *
+ */
+function getBreadcrumbsMarkup(pathList, lang) {
   /**
-   * @param {{url: string, label: string}} pathList
-   * @param {string} lang, e.g. "en"
-   *
-   * @returns {Handlebars.SafeString|null} HTML as safe string (no need to escape)
-   *
-   * Example
-   * {{breadcrumbs pathList lang}}
+   * list of anchor tags
+   * @type {string[]}
    */
-  function breadcrumbs(pathList, lang) {
-    const pathListIsValid =
-      Array.isArray(pathList) &&
-      pathList.every(
-        item => typeof item.label === 'string' && item.label !== '' && typeof item.url === 'string' && item.url !== ''
-      )
-    if (!pathListIsValid) {
-      log.warn('[breadcrumbs] helper requires first parameter to be a list of path item objects')
-      return null
-    }
+  const listItems = []
 
-    /**
-     * list of anchor tags
-     * @type {string[]}
-     */
-    const listItems = []
+  pathList.forEach(({ url, label }) => {
+    listItems.push(`<a href="${url}">${label}</a>`)
+  })
 
-    pathList.forEach(({ url, label }) => {
-      listItems.push(`<a href="${url}">${label}</a>`)
-    })
+  const ariaLabel = /^sv/.test(lang) ? 'Brödsmulor' : 'Breadcrumbs'
 
-    const ariaLabel = /^sv/.test(lang) ? 'Brödsmulor' : 'Breadcrumbs'
+  const output = `
+  <nav id="breadcrumbs" aria-label="${ariaLabel}" class="col-12 col-md-9">
+    <ol class="breadcrumb">
+      ${listItems.map(item => `<li class="breadcrumb-item">${item}</li>`)}
+    </ol>
+  </nav>
+`
+  return output
+}
 
-    const output =
-      '\n' +
-      `    <nav id="breadcrumbs" aria-label="${ariaLabel}" class="col-12 col-md-9">\n` +
-      '      <ol class="breadcrumb">\n' +
-      listItems.map(item => `        <li class="breadcrumb-item">${item}</li>\n`).join('') +
-      '      </ol>\n' +
-      '    </nav>\n'
-
-    return new Handlebars.SafeString(output)
+/**
+ * @param {{url: string, label: string}[]} pathList
+ * @param {string} lang, e.g. "en"
+ *
+ * @returns {Handlebars.SafeString|null} HTML as safe string (no need to escape)
+ *
+ * Example
+ * {{breadcrumbs pathList lang}}
+ */
+function breadcrumbs(pathList, lang) {
+  const pathListIsValid =
+    Array.isArray(pathList) &&
+    pathList.every(
+      item => typeof item.label === 'string' && item.label !== '' && typeof item.url === 'string' && item.url !== ''
+    )
+  if (!pathListIsValid) {
+    log.warn('[breadcrumbs] helper requires first parameter to be a list of path item objects')
+    return null
   }
+  const output = getBreadcrumbsMarkup(pathList, lang)
+  return new Handlebars.SafeString(output)
+}
 
+function registerBreadcrumbHelper() {
   Handlebars.registerHelper('breadcrumbs', breadcrumbs)
+}
+
+module.exports = {
+  registerBreadcrumbHelper,
+  breadcrumbs,
+  getBreadcrumbsMarkup,
 }

--- a/lib/handlebars/helpers/breadcrumbs.js
+++ b/lib/handlebars/helpers/breadcrumbs.js
@@ -26,7 +26,7 @@ function getBreadcrumbsMarkup(pathList, lang) {
   const output = `
   <nav id="breadcrumbs" aria-label="${ariaLabel}" class="col-12 col-md-9">
     <ol class="breadcrumb">
-      ${listItems.map(item => `<li class="breadcrumb-item">${item}</li>`)}
+      ${listItems.reduce((items, item) => items + `<li class="breadcrumb-item">${item}</li>`, '')}
     </ol>
   </nav>
 `.replace(/,/g, '')

--- a/lib/handlebars/helpers/breadcrumbs.js
+++ b/lib/handlebars/helpers/breadcrumbs.js
@@ -29,7 +29,7 @@ function getBreadcrumbsMarkup(pathList, lang) {
       ${listItems.map(item => `<li class="breadcrumb-item">${item}</li>`)}
     </ol>
   </nav>
-`
+`.replace(/,/g, '')
   return output
 }
 

--- a/lib/handlebars/helpers/breadcrumbs.test.js
+++ b/lib/handlebars/helpers/breadcrumbs.test.js
@@ -1,0 +1,73 @@
+const handlebars = require('handlebars')
+const log = require('@kth/log')
+const { registerBreadcrumbHelper, breadcrumbs, getBreadcrumbsMarkup } = require('./breadcrumbs')
+
+jest.mock('@kth/log')
+jest.mock('handlebars')
+
+describe('registerBreadcrumbHelper', () => {
+  it('Registers breadcrumbs helper', () => {
+    registerBreadcrumbHelper()
+    expect(handlebars.registerHelper).toHaveBeenCalledWith('breadcrumbs', breadcrumbs)
+  })
+})
+
+describe('getBreadcrumbsMarkup', () => {
+  it('should return null and log a warning if the input is not a valid path list', () => {
+    const invalidPathList = [{}]
+    const result = breadcrumbs(invalidPathList, 'en')
+    expect(result).toBeNull()
+    expect(log.warn).toHaveBeenCalledWith(
+      '[breadcrumbs] helper requires first parameter to be a list of path item objects'
+    )
+  })
+
+  it('should generate breadcrumbs HTML for a valid path list in English', () => {
+    const validPathList = [
+      { url: '/', label: 'Kth' },
+      { url: '/test1', label: 'Test 1' },
+      { url: '/test2', label: 'Test 2' },
+    ]
+    const result = getBreadcrumbsMarkup(validPathList, 'en')
+
+    // Define the expected output
+    const expectedOutput = `
+        <nav id="breadcrumbs" aria-label="Breadcrumbs" class="col-12 col-md-9">
+          <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/">Kth</a></li>
+            <li class="breadcrumb-item"><a href="/test1">Test 1</a></li>
+            <li class="breadcrumb-item"><a href="/test2">Test 2</a></li>
+          </ol>
+        </nav>
+      `
+      .trim()
+      .replace(/[\s,]+/g, '')
+
+    // Remove white spaces and compare the results
+    expect(result.trim().replace(/[\s,]+/g, '')).toBe(expectedOutput)
+  })
+
+  it('should generate breadcrumbs HTML for a valid path list in Swedish', () => {
+    const validPathList = [
+      { url: '/', label: 'Kth' },
+      { url: '/test1', label: 'Test 1' },
+      { url: '/test2', label: 'Test 2' },
+    ]
+    const result = getBreadcrumbsMarkup(validPathList, 'sv')
+
+    const expectedOutput = `
+        <nav id="breadcrumbs" aria-label="Brödsmulor" class="col-12 col-md-9">
+          <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/">Kth</a></li>
+            <li class="breadcrumb-item"><a href="/test1">Test 1</a></li>
+            <li class="breadcrumb-item"><a href="/test2">Test 2</a></li>
+          </ol>
+        </nav>
+      `
+      .trim()
+      .replace(/[\s,]+/g, '')
+
+    // Remove white spaces and compare the results
+    expect(result.trim().replace(/[\s,]+/g, '')).toBe(expectedOutput)
+  })
+})

--- a/lib/handlebars/helpers/breadcrumbs.test.js
+++ b/lib/handlebars/helpers/breadcrumbs.test.js
@@ -29,22 +29,7 @@ describe('getBreadcrumbsMarkup', () => {
       { url: '/test2', label: 'Test 2' },
     ]
     const result = getBreadcrumbsMarkup(validPathList, 'en')
-
-    // Define the expected output
-    const expectedOutput = `
-        <nav id="breadcrumbs" aria-label="Breadcrumbs" class="col-12 col-md-9">
-          <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="/">Kth</a></li>
-            <li class="breadcrumb-item"><a href="/test1">Test 1</a></li>
-            <li class="breadcrumb-item"><a href="/test2">Test 2</a></li>
-          </ol>
-        </nav>
-      `
-      .trim()
-      .replace(/[\s,]+/g, '')
-
-    // Remove white spaces and compare the results
-    expect(result.trim().replace(/[\s,]+/g, '')).toBe(expectedOutput)
+    expect(result).toMatchSnapshot()
   })
 
   it('should generate breadcrumbs HTML for a valid path list in Swedish', () => {
@@ -54,20 +39,6 @@ describe('getBreadcrumbsMarkup', () => {
       { url: '/test2', label: 'Test 2' },
     ]
     const result = getBreadcrumbsMarkup(validPathList, 'sv')
-
-    const expectedOutput = `
-        <nav id="breadcrumbs" aria-label="Brödsmulor" class="col-12 col-md-9">
-          <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a href="/">Kth</a></li>
-            <li class="breadcrumb-item"><a href="/test1">Test 1</a></li>
-            <li class="breadcrumb-item"><a href="/test2">Test 2</a></li>
-          </ol>
-        </nav>
-      `
-      .trim()
-      .replace(/[\s,]+/g, '')
-
-    // Remove white spaces and compare the results
-    expect(result.trim().replace(/[\s,]+/g, '')).toBe(expectedOutput)
+    expect(result).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
Purpose of this pr is to provide more granular config of breadcrumbs. Before, a default root breadcrumbs was hardcoded to with label kth, which won't work on kth intranet.