### PR TITLE
Feat/legacy blockview for style versions

### DIFF
--- a/lib/web/cortina.js
+++ b/lib/web/cortina.js
@@ -27,7 +27,11 @@ module.exports = function cortinaCommon(options) {
     redisKey,
     siteNameKey = 'site_name',
     localeTextKey = 'locale_text',
+    styleVersion = 9,
   } = options
+
+  const blockView = styleVersion == 10 ? 'style10' : 'style9'
+
   let { supportedLanguages = ['sv', 'en'] } = options
   if (!supportedLanguages.length) supportedLanguages = ['sv', 'en']
   const globalLink = supportedLanguages.length === 1 ? true : options.globalLink || false
@@ -70,6 +74,7 @@ module.exports = function cortinaCommon(options) {
       redis: client,
       blocks: addBlocks,
       redisKey,
+      version: blockView,
     })
       .then(blocks => {
         res.locals.blocks = _prepareBlocks(req, res, blocks)

--- a/lib/web/cortina.js
+++ b/lib/web/cortina.js
@@ -26,11 +26,11 @@ module.exports = function cortinaCommon(options) {
     redisConfig,
     siteNameKey = 'site_name',
     localeTextKey = 'locale_text',
-    styleVersion = 9,
+    useStyle10 = false,
   } = options
 
-  const blockView = styleVersion == 10 ? 'style10' : 'style9'
-  const redisKey = (options.redisKey || 'CortinaBlock_') + (styleVersion == 10 ? 'style10_' : 'style9_')
+  const blockView = useStyle10 ? 'style10' : 'style9'
+  const redisKey = (options.redisKey || 'CortinaBlock_') + (useStyle10 ? 'style10_' : 'style9_')
 
   let { supportedLanguages = ['sv', 'en'] } = options
   if (!supportedLanguages.length) supportedLanguages = ['sv', 'en']

--- a/lib/web/cortina.js
+++ b/lib/web/cortina.js
@@ -24,13 +24,13 @@ module.exports = function cortinaCommon(options) {
     proxyPrefixPath,
     hostUrl,
     redisConfig,
-    redisKey,
     siteNameKey = 'site_name',
     localeTextKey = 'locale_text',
     styleVersion = 9,
   } = options
 
   const blockView = styleVersion == 10 ? 'style10' : 'style9'
+  const redisKey = (options.redisKey || 'CortinaBlock_') + (styleVersion == 10 ? 'style10_' : 'style9_')
 
   let { supportedLanguages = ['sv', 'en'] } = options
   if (!supportedLanguages.length) supportedLanguages = ['sv', 'en']

--- a/lib/web/cortina.test.js
+++ b/lib/web/cortina.test.js
@@ -12,9 +12,9 @@ describe('cortina wrapper styleVersion', () => {
 
   mockCortinaPackage.mockResolvedValue([])
 
-  test('use "view style10" for styleVersion 10', async () => {
+  test('use "view style10" when useStyle10 is true', async () => {
     const options = {
-      styleVersion: 10,
+      useStyle10: true,
     }
 
     const middleware = cortina(options)
@@ -23,9 +23,9 @@ describe('cortina wrapper styleVersion', () => {
 
     expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ version: 'style10' }))
   })
-  test('use "view style9" for styleVersion 9', async () => {
+  test('use "view style9" when useStyle10 is false', async () => {
     const options = {
-      styleVersion: 9,
+      useStyle10: false,
     }
 
     const middleware = cortina(options)
@@ -34,9 +34,9 @@ describe('cortina wrapper styleVersion', () => {
 
     expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ version: 'style9' }))
   })
-  test('use "view style9" when styleVersion is missing', async () => {
+  test('use "view style9" when useStyle10 is missing', async () => {
     const options = {
-      styleVersion: undefined,
+      useStyle10: undefined,
     }
 
     const middleware = cortina(options)
@@ -46,9 +46,9 @@ describe('cortina wrapper styleVersion', () => {
     expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ version: 'style9' }))
   })
 
-  test('use redis key with "_style10" for styleVersion 10', async () => {
+  test('use redis key with "_style10" when useStyle10 is true', async () => {
     const options = {
-      styleVersion: 10,
+      useStyle10: true,
     }
 
     const middleware = cortina(options)
@@ -57,9 +57,9 @@ describe('cortina wrapper styleVersion', () => {
 
     expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ redisKey: 'CortinaBlock_style10_' }))
   })
-  test('use redis key with "_style9" for styleVersion 9', async () => {
+  test('use redis key with "_style9" when useStyle10 is false', async () => {
     const options = {
-      styleVersion: 9,
+      useStyle10: false,
     }
 
     const middleware = cortina(options)
@@ -68,9 +68,9 @@ describe('cortina wrapper styleVersion', () => {
 
     expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ redisKey: 'CortinaBlock_style9_' }))
   })
-  test('use redis key with "_style9" when styleVersion is missing', async () => {
+  test('use redis key with "_style9" when useStyle10 is missing', async () => {
     const options = {
-      styleVersion: undefined,
+      useStyle10: undefined,
     }
 
     const middleware = cortina(options)
@@ -82,7 +82,7 @@ describe('cortina wrapper styleVersion', () => {
   test('combine style suffix with custom key', async () => {
     const options = {
       redisKey: 'custom_key_',
-      styleVersion: 10,
+      useStyle10: true,
     }
 
     const middleware = cortina(options)

--- a/lib/web/cortina.test.js
+++ b/lib/web/cortina.test.js
@@ -45,4 +45,50 @@ describe('cortina wrapper styleVersion', () => {
 
     expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ version: 'style9' }))
   })
+
+  test('use redis key with "_style10" for styleVersion 10', async () => {
+    const options = {
+      styleVersion: 10,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ redisKey: 'CortinaBlock_style10_' }))
+  })
+  test('use redis key with "_style9" for styleVersion 9', async () => {
+    const options = {
+      styleVersion: 9,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ redisKey: 'CortinaBlock_style9_' }))
+  })
+  test('use redis key with "_style9" when styleVersion is missing', async () => {
+    const options = {
+      styleVersion: undefined,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ redisKey: 'CortinaBlock_style9_' }))
+  })
+  test('combine style suffix with custom key', async () => {
+    const options = {
+      redisKey: 'custom_key_',
+      styleVersion: 10,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ redisKey: 'custom_key_style10_' }))
+  })
 })

--- a/lib/web/cortina.test.js
+++ b/lib/web/cortina.test.js
@@ -1,0 +1,48 @@
+const cortina = require('./cortina')
+
+jest.mock('@kth/log', () => ({ error: jest.fn() }))
+
+jest.mock('@kth/cortina-block', () => jest.fn())
+const mockCortinaPackage = require('@kth/cortina-block')
+
+describe('cortina wrapper styleVersion', () => {
+  const mockReq = { query: {}, url: '', hostname: '' }
+  const mockRes = { locals: {} }
+  const mockNext = jest.fn()
+
+  mockCortinaPackage.mockResolvedValue([])
+
+  test('use "view style10" for styleVersion 10', async () => {
+    const options = {
+      styleVersion: 10,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ version: 'style10' }))
+  })
+  test('use "view style9" for styleVersion 9', async () => {
+    const options = {
+      styleVersion: 9,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ version: 'style9' }))
+  })
+  test('use "view style9" when styleVersion is missing', async () => {
+    const options = {
+      styleVersion: undefined,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ version: 'style9' }))
+  })
+})


### PR DESCRIPTION
https://trello.com/c/YHpunuMU/2994-l%C3%A4gg-tillbaka-m%C3%B6jligheten-att-ange-view-i-kth-cortina-block

For apps that use @kth/cortina-block package via @kth/kth-node-web-common


Logic to fetch specific views already exists in @kth/cortina-block, however it is named "version" for some reason.