### PR TITLE
specify block view based on styleVersion

### DIFF
--- a/lib/web/cortina.js
+++ b/lib/web/cortina.js
@@ -24,10 +24,14 @@ module.exports = function cortinaCommon(options) {
     proxyPrefixPath,
     hostUrl,
     redisConfig,
-    redisKey,
     siteNameKey = 'site_name',
     localeTextKey = 'locale_text',
+    useStyle10 = false,
   } = options
+
+  const blockView = useStyle10 ? 'style10' : 'style9'
+  const redisKey = (options.redisKey || 'CortinaBlock_') + (useStyle10 ? 'style10_' : 'style9_')
+
   let { supportedLanguages = ['sv', 'en'] } = options
   if (!supportedLanguages.length) supportedLanguages = ['sv', 'en']
   const globalLink = supportedLanguages.length === 1 ? true : options.globalLink || false
@@ -70,6 +74,7 @@ module.exports = function cortinaCommon(options) {
       redis: client,
       blocks: addBlocks,
       redisKey,
+      version: blockView,
     })
       .then(blocks => {
         res.locals.blocks = _prepareBlocks(req, res, blocks)

--- a/lib/web/cortina.test.js
+++ b/lib/web/cortina.test.js
@@ -1,0 +1,94 @@
+const cortina = require('./cortina')
+
+jest.mock('@kth/log', () => ({ error: jest.fn() }))
+
+jest.mock('@kth/cortina-block', () => jest.fn())
+const mockCortinaPackage = require('@kth/cortina-block')
+
+describe('cortina wrapper styleVersion', () => {
+  const mockReq = { query: {}, url: '', hostname: '' }
+  const mockRes = { locals: {} }
+  const mockNext = jest.fn()
+
+  mockCortinaPackage.mockResolvedValue([])
+
+  test('use "view style10" when useStyle10 is true', async () => {
+    const options = {
+      useStyle10: true,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ version: 'style10' }))
+  })
+  test('use "view style9" when useStyle10 is false', async () => {
+    const options = {
+      useStyle10: false,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ version: 'style9' }))
+  })
+  test('use "view style9" when useStyle10 is missing', async () => {
+    const options = {
+      useStyle10: undefined,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ version: 'style9' }))
+  })
+
+  test('use redis key with "_style10" when useStyle10 is true', async () => {
+    const options = {
+      useStyle10: true,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ redisKey: 'CortinaBlock_style10_' }))
+  })
+  test('use redis key with "_style9" when useStyle10 is false', async () => {
+    const options = {
+      useStyle10: false,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ redisKey: 'CortinaBlock_style9_' }))
+  })
+  test('use redis key with "_style9" when useStyle10 is missing', async () => {
+    const options = {
+      useStyle10: undefined,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ redisKey: 'CortinaBlock_style9_' }))
+  })
+  test('combine style suffix with custom key', async () => {
+    const options = {
+      redisKey: 'custom_key_',
+      useStyle10: true,
+    }
+
+    const middleware = cortina(options)
+
+    await middleware(mockReq, mockRes, mockNext)
+
+    expect(mockCortinaPackage).toBeCalledWith(expect.objectContaining({ redisKey: 'custom_key_style10_' }))
+  })
+})


### PR DESCRIPTION
https://trello.com/c/YHpunuMU/2994-l%C3%A4gg-tillbaka-m%C3%B6jligheten-att-ange-view-i-kth-cortina-block

For apps that use @kth/cortina-block package via @kth/kth-node-web-common

Logic to fetch specific views already exists in @kth/cortina-block, however it is named "version" for some reason.