### PR TITLE
remove stacktrace from 404 logs

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -55,7 +55,7 @@ function _renderErrorPage(res, req, statusCode, i18n, isProd, lang, err) {
       text = i18n.message('error_403_text', lang)
       break
     case 404:
-      log.info(`404 Not found ${err.message}`, { err })
+      log.info(`404 Not found ${err.message}`)
       headTitle = i18n.message('error_404_head_title', lang)
       headDescription = i18n.message('error_404_description', lang)
       title = i18n.message('error_404_title', lang)


### PR DESCRIPTION
It currently it looks something like this in the logs whenever an app returns a 404
```
404 Not found Not Found: / {
  err: Error: Not Found: /
      at _notFound (/Users/nsan/code/kth/node-apps/search-web/server/controllers/systemCtrl.js:53:15)
      at Layer.handle [as handle_request] (/Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/layer.js:95:5)
      at trim_prefix (/Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/index.js:328:13)
      at /Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/index.js:286:9
      at Function.process_params (/Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/index.js:346:12)
      at next (/Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/index.js:280:10)
      at /Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/index.js:646:15
      at next (/Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/index.js:265:14)
      at Function.handle (/Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/index.js:175:3)
      at router (/Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/index.js:47:12)
      at Layer.handle [as handle_request] (/Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/layer.js:95:5)
      at trim_prefix (/Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/index.js:328:13)
      at /Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/index.js:286:9
      at Function.process_params (/Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/index.js:346:12)
      at next (/Users/nsan/code/kth/node-apps/search-web/node_modules/express/lib/router/index.js:280:10)
      at /Users/nsan/code/kth/node-apps/search-web/node_modules/express-rate-limit/dist/index.cjs:591:9 {
    status: 404
  }
}
```

Feels a bit overkill, and the traces will probably always originate from the same line in systemCtrl.js



The sad part. I decided to keep the message as `log.info(´404 Not found ${err.message}´)` to match the other cases.
But all (or at least most) apps also includes "Not Found" when the error is crated, so the final message now will be something like `404 Not found Not Found: /`.
Feels like a minor inconvenience though.
